### PR TITLE
Back to 1.0.1 version

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,7 +58,9 @@ For more detailed information on installation, find it at (https://support.dotdi
 
 # 1.0.0
  - First release
-
+# 1.0.1
+ - Rebranding
+ 
 ## Contribution
 You are welcome to contribute to Engagement Cloud for Shopware! You can either:
  - Report a bug: create a GitHub issue including description, repro steps, Shopware, bridge and plugin version

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name" : "dotmailer/engagement-cloud-for-shopware",
-	"version" : "1.0.0",
+	"version" : "1.0.1",
 	"require-dev" : {
 		"squizlabs/php_codesniffer" : "*"
 	}

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     },
     "copyright": "Copyright (c) 2017 dotdigital Group PLC",
     "license": "MIT",
-    "link": "https://www.dotmailer.com/",
+    "link": "https://www.dotdigital.com/",
     "author": "dotdigital",
 
     "currentVersion": "1.0.0",

--- a/plugin.json
+++ b/plugin.json
@@ -5,17 +5,19 @@
     },
     "copyright": "Copyright (c) 2017 dotDigital Group PLC",
     "license": "MIT",
-    "link": "https://www.dotdigital.com/",
+    "link": "https://www.dotmailer.com/",
     "author": "dotdigital",
 
     "currentVersion": "1.0.0",
 
     "changelog": {
         "de": {
-            "1.0.0": "Erstveröffentlichung"
+            "1.0.0": "Erstveröffentlichung",
+			"1.0.1": "Rebranding"
         },
         "en": {
-            "1.0.0": "First release"
+            "1.0.0": "First release",
+			"1.0.1": "Rebranding"
         }
     },
 

--- a/plugin.json
+++ b/plugin.json
@@ -3,21 +3,19 @@
         "de": "dotdigital Engagement Cloud",
         "en": "dotdigital Engagement Cloud"
     },
-    "copyright": "Copyright (c) 2017 dotDigital Group PLC",
+    "copyright": "Copyright (c) 2017 dotdigital Group PLC",
     "license": "MIT",
-    "link": "https://www.dotmailer.com/",
+    "link": "https://www.dotdigital.com/",
     "author": "dotdigital",
 
     "currentVersion": "1.0.0",
 
     "changelog": {
         "de": {
-            "1.0.0": "Erstveröffentlichung",
-			"1.0.1": "Rebranding"
+            "1.0.0": "Erstveröffentlichung"
         },
         "en": {
-            "1.0.0": "First release",
-			"1.0.1": "Rebranding"
+            "1.0.0": "First release"
         }
     },
 

--- a/plugin.json
+++ b/plugin.json
@@ -5,17 +5,19 @@
     },
     "copyright": "Copyright (c) 2017 dotdigital Group PLC",
     "license": "MIT",
-    "link": "https://www.dotdigital.com/",
+    "link": "https://www.dotmailer.com/",
     "author": "dotdigital",
 
     "currentVersion": "1.0.0",
 
     "changelog": {
         "de": {
-            "1.0.0": "Erstveröffentlichung"
+            "1.0.0": "Erstveröffentlichung",
+			"1.0.1": "Rebranding"
         },
         "en": {
-            "1.0.0": "First release"
+            "1.0.0": "First release",
+			"1.0.1": "Rebranding"
         }
     },
 


### PR DESCRIPTION
Fixed `plugin.json` file, eclipse encoding (this is a guess) did something so Shopware thouth the plugin was writen following the new plugin framework.