### PR TITLE
Change Marketing menu item to use a relative URL

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -125,13 +125,10 @@ class Shopware_Plugins_Backend_DotmailerEmailMarketing_Bootstrap extends Shopwar
 
     public function addMenuItem()
     {
-        $em = $this->Application()->Models();
-        $url = $em->find('Shopware\Models\Shop\Shop', 1)->getBasePath() . '/backend/dotmailer/connect';
-
         $this->createMenuItem(
             array(
             'label' => 'dotdigital Engagement Cloud',
-            'onclick' => 'window.open("' . $url . '", "_blank")',
+            'onclick' => 'window.open("/backend/dotmailer/connect", "_blank")',
             'class' => 'sprite-dotmailer-email-marketing',
             'active' => 1,
             'parent' => $this->Menu()->findOneBy(array('label' => 'Marketing'))

--- a/Readme.md
+++ b/Readme.md
@@ -60,6 +60,8 @@ For more detailed information on installation, find it at (https://support.dotdi
  - First release
 # 1.0.1
  - Rebranding
+# 1.0.2
+ - Use relative URL in "Marketing" menu item
  
 ## Contribution
 You are welcome to contribute to Engagement Cloud for Shopware! You can either:

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name" : "dotmailer/engagement-cloud-for-shopware",
-	"version" : "1.0.1",
+	"version" : "1.0.2",
 	"require-dev" : {
 		"squizlabs/php_codesniffer" : "*"
 	}

--- a/plugin.json
+++ b/plugin.json
@@ -8,16 +8,18 @@
     "link": "https://www.dotdigital.com/",
     "author": "dotdigital",
 
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
 
     "changelog": {
         "de": {
             "1.0.0": "Erstveröffentlichung",
-			"1.0.1": "Rebranding"
+			"1.0.1": "Rebranding",
+			"1.0.2": "Verwenden Sie die relative URL im Menüelement \"Marketing\""
         },
         "en": {
             "1.0.0": "First release",
-			"1.0.1": "Rebranding"
+			"1.0.1": "Rebranding",
+			"1.0.2": "Use relative URL in \"Marketing\" menu item"
         }
     },
 


### PR DESCRIPTION
### Overview

In 1.0.1 and below the URL the merketing menu item opens is set to an absolute URL that is calculated using:

`$this->Application()->Models()->find('Shopware\Models\Shop\Shop', 1)->getBasePath()`

This returns null or empty string in one of our test stores running on nginx.

This means the menu item requests `https://backend/dotmailer/connect` which 404s.

### Fix

This PR removes the use of `getBasePath()` and uses a relative URL.

### How to test

- Install and activate the plugin from this PR
- Click Marketing > dotdigital Engagement Cloud
- You should be redirected to Engagement Cloud and either:
  - Be asked to login
  - Told you have a store connected
  - Be told you're "almost there!"